### PR TITLE
Redesign UI with a GitHub Primer–inspired light theme

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -5,50 +5,73 @@
 }
 
 :root {
-  /* Surfaces — gunmetal greyscale, darker→lighter */
-  --ea--surface-1: #1c1b1b;
-  --ea--surface-2: #313030;
-  --ea--surface-3: #474646;
-  --ea--surface-4: #5f5e5e;
-  --ea--surface-5: #787776;
+  /* ---------------------------------------------------------------------
+   * GitHub Primer–inspired light theme.
+   * Surfaces step from the page canvas (subtle grey) up to white cards.
+   * ------------------------------------------------------------------- */
+  --ea--surface-1: #f6f8fa; /* page canvas (canvas.subtle) */
+  --ea--surface-2: #ffffff; /* cards / raised surfaces */
+  --ea--surface-3: #f6f8fa; /* nested panel */
+  --ea--surface-4: #eaeef2; /* deeper nested */
+  --ea--surface-5: #d8dee4; /* deepest nested */
 
   /* Canonical surface aliases (used throughout components) */
   --ea-surface-0: var(--ea--surface-2);
-  --ea-surface-50: #2a2929;
-  --ea-surface-100: #3a3939;
+  --ea-surface-50: #f6f8fa;
+  --ea-surface-100: #f6f8fa;
   --ea-surface-card: var(--ea--surface-2);
-  --ea-surface-border: var(--ea--surface-3);
+  --ea-surface-border: #d0d7de; /* border.default */
+  --ea-surface-border-muted: #d8dee4; /* border.muted */
 
-  /* Brand hues */
-  --ea-primary: #9a031e;
-  --ea-secondary: #4a4e54;
-  --ea-tertiary: #c5a059;
+  /* Global navigation header (GitHub's dark top bar) */
+  --ea-header-bg: #1f2328;
+  --ea-header-fg: #ffffff;
+  --ea-header-fg-muted: rgb(255 255 255 / 70%);
+  --ea-header-border: #2f343a;
 
-  --ea-gold-bright: #d8b978;
-  --ea-gold-dim: #9c7c43;
-  --ea-crimson-bright: #c20a2b;
-  --ea-crimson-dim: #6f0216;
+  /* Brand / accent hues — green primary action, blue links (GitHub) */
+  --ea-primary: #1f883d; /* btn-primary / success emphasis */
+  --ea-primary-hover: #1a7f37;
+  --ea-secondary: #59636e;
+  --ea-tertiary: #0969da; /* accent.fg — links, active tabs */
+  --ea-accent: #0969da;
+  --ea-accent-hover: #0860ca;
+
+  /* Semantic states */
+  --ea-success-fg: #1a7f37;
+  --ea-success-emphasis: #1f883d;
+  --ea-success-subtle: #dafbe1;
+  --ea-danger-fg: #cf222e;
+  --ea-danger-emphasis: #cf222e;
+  --ea-danger-subtle: #ffebe9;
+  --ea-attention-fg: #9a6700;
+  --ea-attention-subtle: #fff8c5;
+  --ea-attention-border: #d4a72c;
 
   /* Semantic color aliases */
   --ea-primary-color: var(--ea-primary);
-  --ea-primary-contrast-color: #f4f1ec;
-  --ea-message-warn-outlined-color: var(--ea-tertiary);
+  --ea-primary-contrast-color: #ffffff;
+  --ea-message-warn-outlined-color: var(--ea-attention-fg);
 
   /* Text */
-  --ea--text-color: #dfe2ea;
-  --ea--text-muted-color: #a8abb2;
+  --ea--text-color: #1f2328; /* fg.default */
+  --ea--text-muted-color: #59636e; /* fg.muted */
   --ea-text-color: var(--ea--text-color);
   --ea-text-muted-color: var(--ea--text-muted-color);
-  --ea-text-faint-color: #74767d;
+  --ea-text-faint-color: #818b98; /* fg.subtle */
+  --ea-link-color: var(--ea-accent);
 
-  /* Typography */
-  --ea--font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  --ea-font-display: 'Georgia', 'Times New Roman', serif;
+  /* Typography — GitHub system stack, no decorative serif headings */
+  --ea--font-family:
+    -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial, sans-serif,
+    'Apple Color Emoji', 'Segoe UI Emoji';
+  --ea-font-display: var(--ea--font-family);
   --ea-font-body: var(--ea--font-family);
-  --ea-font-mono: ui-monospace, 'SF Mono', 'Cascadia Code', Menlo, monospace;
+  --ea-font-mono: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono',
+    monospace;
 
   /* Type scale */
-  --ea-text-display: 2rem;
+  --ea-text-display: 1.75rem;
   --ea-text-h1: 1.4rem;
   --ea-text-h2: 1.15rem;
   --ea-text-h3: 1rem;
@@ -56,16 +79,17 @@
   --ea-text-xs: 0.75rem;
 
   /* Radii & borders */
-  --ea-radius-sharp: 1px;
-  --ea-radius-sm: 0.375rem;
-  --ea-radius-md: 0.5rem;
+  --ea-radius-sharp: 3px;
+  --ea-radius-sm: 6px;
+  --ea-radius-md: 6px;
   --ea-radius-pill: 999px;
   --ea-border-radius: var(--ea-radius-sm);
 
-  /* Elevation */
-  --ea-shadow-card: 0 1px 2px rgb(0 0 0 / 35%);
-  --ea-shadow-dialog: 0 12px 40px rgb(0 0 0 / 55%);
-  --ea-accent-rail: 4px solid var(--ea-tertiary);
+  /* Elevation — Primer's restrained shadows */
+  --ea-shadow-card: 0 1px 0 rgb(31 35 40 / 4%);
+  --ea-shadow-medium: 0 3px 6px rgb(31 35 40 / 12%);
+  --ea-shadow-dialog: 0 8px 24px rgb(66 74 83 / 12%), 0 1px 3px rgb(27 31 36 / 12%);
+  --ea-accent-rail: 4px solid var(--ea-accent);
 }
 
 html,
@@ -74,6 +98,9 @@ body {
   padding: 0;
   font-family: var(--ea--font-family, system-ui, sans-serif);
   font-weight: 400;
+  font-size: 14px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
   background-color: var(--ea--surface-1);
   color: var(--ea--text-color);
   min-height: 100dvh;
@@ -87,12 +114,51 @@ h5,
 h6,
 .header {
   font-family: var(--ea-font-display);
-  text-transform: uppercase;
-  color: var(--ea-tertiary);
+  color: var(--ea-text-color);
   font-weight: 600;
-  letter-spacing: 0.04em;
+  letter-spacing: -0.01em;
   margin: 0;
-  line-height: 1.18;
+  line-height: 1.25;
+}
+
+a {
+  color: var(--ea-link-color);
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+/* Primer-style form controls */
+input[type='text'],
+input[type='number'],
+input[type='search'],
+input[type='email'],
+select,
+textarea {
+  font: inherit;
+  color: var(--ea-text-color);
+  background: var(--ea-surface-0);
+  border: 1px solid var(--ea-surface-border);
+  border-radius: var(--ea-radius-md);
+  padding: 0.34rem 0.7rem;
+  line-height: 1.4;
+  box-shadow: inset 0 1px 0 rgb(208 215 222 / 20%);
+  transition:
+    border-color 0.15s ease,
+    box-shadow 0.15s ease;
+}
+
+input[type='text']:focus,
+input[type='number']:focus,
+input[type='search']:focus,
+input[type='email']:focus,
+select:focus,
+textarea:focus {
+  outline: none;
+  border-color: var(--ea-accent);
+  box-shadow: 0 0 0 3px rgb(9 105 218 / 30%);
 }
 
 #app {

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -19,6 +19,7 @@
   --ea-surface-0: var(--ea--surface-2);
   --ea-surface-50: #f6f8fa;
   --ea-surface-100: #f6f8fa;
+  --ea-surface-200: #eaeef2;
   --ea-surface-card: var(--ea--surface-2);
   --ea-surface-border: #d0d7de; /* border.default */
   --ea-surface-border-muted: #d8dee4; /* border.muted */
@@ -36,6 +37,8 @@
   --ea-tertiary: #0969da; /* accent.fg — links, active tabs */
   --ea-accent: #0969da;
   --ea-accent-hover: #0860ca;
+  --ea-accent-subtle: #ddf4ff; /* accent.subtle — selected rows */
+  --ea-accent-muted: #54aeff; /* accent.muted — selected borders */
 
   /* Semantic states */
   --ea-success-fg: #1a7f37;

--- a/src/components/editor/AddDetachmentDialog.vue
+++ b/src/components/editor/AddDetachmentDialog.vue
@@ -129,8 +129,9 @@ function confirm() {
 .dialog {
   width: min(95vw, 520px);
   background: var(--ea-surface-0);
-  border-radius: 0.5rem;
+  border-radius: var(--ea-radius-md);
   border: 1px solid var(--ea-surface-border);
+  box-shadow: var(--ea-shadow-dialog);
   padding: 1rem;
 }
 
@@ -153,9 +154,14 @@ function confirm() {
   cursor: pointer;
 }
 
+.group-tab:hover {
+  background: var(--ea-surface-50);
+}
+
 .group-tab.active {
-  border-color: var(--ea-primary-color);
-  color: var(--ea-primary-color);
+  border-color: var(--ea-accent);
+  background: var(--ea-accent-subtle);
+  color: var(--ea-accent);
 }
 
 .det-list {
@@ -174,10 +180,14 @@ function confirm() {
   background: var(--ea-surface-0);
 }
 
-.det-option:hover,
+.det-option:hover {
+  border-color: var(--ea-accent-muted);
+  background: var(--ea-surface-50);
+}
+
 .det-option.selected {
-  border-color: var(--ea-primary-color);
-  background: var(--ea-primary-50);
+  border-color: var(--ea-accent);
+  background: var(--ea-accent-subtle);
 }
 
 .det-header {

--- a/src/components/editor/DetachmentCard.vue
+++ b/src/components/editor/DetachmentCard.vue
@@ -182,14 +182,15 @@ function isTransportUpgrade(upgradeName: string): boolean {
 
 <style scoped>
 .detachment-card {
-  border-left: 4px solid var(--ea-tertiary);
-  &.warning-card {
-    border-color: var(--ea-primary);
-  }
+  border: 1px solid var(--ea-surface-border);
+  border-left: 4px solid var(--ea-accent);
+  border-radius: var(--ea-radius-md);
+  box-shadow: var(--ea-shadow-card);
 }
 
 .warning-card {
-  outline: 1px solid var(--ea-message-warn-outlined-color);
+  border-left-color: var(--ea-attention-border);
+  outline: 1px solid var(--ea-attention-border);
 }
 
 .info {
@@ -198,13 +199,18 @@ function isTransportUpgrade(upgradeName: string): boolean {
   flex-shrink: 0;
   gap: 0.5rem;
 }
+
+.detachment-card > details {
+  border: 1px solid var(--ea-surface-border);
+  border-radius: var(--ea-radius-md);
+}
 .header {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  justify-content: center;
-  color: var(--ea-tertiary);
-  border-bottom: 1px solid;
+  color: var(--ea-text-color);
+  font-weight: 600;
+  border-bottom: 1px solid var(--ea-surface-border);
   padding-bottom: 0.5rem;
 }
 
@@ -229,11 +235,11 @@ function isTransportUpgrade(upgradeName: string): boolean {
 }
 
 .detachment-number-badge {
-  min-width: 1em;
-  height: 1em;
-  border-radius: 1px;
-  background: var(--ea-tertiary);
-  color: #000;
+  min-width: 1.5em;
+  height: 1.5em;
+  border-radius: var(--ea-radius-sm);
+  background: var(--ea-accent);
+  color: #ffffff;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -306,28 +312,38 @@ details[open] .toggle-indicator::after {
 }
 
 .primary-button {
-  border: 1px solid var(--ea-primary-color);
+  border: 1px solid rgb(31 35 40 / 15%);
   background: var(--ea-primary-color);
   color: var(--ea-primary-contrast-color);
 }
 
+.primary-button:hover {
+  background: var(--ea-primary-hover);
+}
+
 .secondary-button {
   border: 1px solid var(--ea-surface-border);
-  background: var(--ea-surface-0);
-  color: inherit;
+  background: var(--ea-surface-50);
+  color: var(--ea-text-color);
+}
+
+.secondary-button:hover:not(:disabled) {
+  background: #eef1f3;
+  border-color: rgb(31 35 40 / 15%);
 }
 
 .danger-button,
 .remove-upgrade-button {
-  border: 1px solid var(--ea-tertiary);
-  background: transparent;
-  color: var(--ea-tertiary);
+  border: 1px solid var(--ea-surface-border);
+  background: var(--ea-surface-50);
+  color: var(--ea-danger-fg);
 }
 
 .danger-button:hover,
 .remove-upgrade-button:hover {
-  background: var(--ea-tertiary);
-  color: #1c1b1b;
+  background: var(--ea-danger-emphasis);
+  border-color: var(--ea-danger-emphasis);
+  color: #ffffff;
 }
 
 .secondary-button:disabled {
@@ -338,16 +354,19 @@ details[open] .toggle-indicator::after {
 .transport-warning {
   margin-top: 0.75rem;
   padding: 0.4rem 0.6rem;
-  border-radius: 0.375rem;
+  border-radius: var(--ea-radius-md);
+  font-size: 0.8125rem;
 }
 
 .transport-warning.warn {
-  background: #fff7ed;
-  color: #9a3412;
+  background: var(--ea-attention-subtle);
+  color: var(--ea-attention-fg);
+  border: 1px solid var(--ea-attention-border);
 }
 
 .transport-warning.error {
-  background: #fef2f2;
-  color: #991b1b;
+  background: var(--ea-danger-subtle);
+  color: var(--ea-danger-fg);
+  border: 1px solid rgb(255 129 130 / 60%);
 }
 </style>

--- a/src/components/editor/UnitPanel.vue
+++ b/src/components/editor/UnitPanel.vue
@@ -85,49 +85,68 @@ function incrementAmount() {
 .amount-control {
   display: inline-flex;
   align-items: center;
-  border: 1px solid var(--ea-gold-bright);
-  border-radius: var(--ea-radius-pill);
+  border: 1px solid var(--ea-surface-border);
+  border-radius: var(--ea-radius-md);
+  background: var(--ea-surface-0);
   overflow: hidden;
 }
 
 .amount-button {
   appearance: none;
   border: 0;
-  background: var(--ea-gold-dim);
-  color: var(--ea--surface-1);
+  background: var(--ea-surface-50);
+  color: var(--ea-text-color);
   min-width: 2.25rem;
   min-height: 2.25rem;
   font: inherit;
-  font-size: 1rem;
+  font-size: 1.1rem;
   line-height: 1;
   cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.amount-button:first-child {
+  border-right: 1px solid var(--ea-surface-border);
+}
+
+.amount-button:last-child {
+  border-left: 1px solid var(--ea-surface-border);
+}
+
+.amount-button:hover:not(:disabled) {
+  background: #eef1f3;
+  color: var(--ea-accent);
 }
 
 .amount-button:disabled {
   cursor: not-allowed;
-  opacity: 0.45;
+  color: var(--ea-text-faint-color);
+  opacity: 0.6;
 }
 
 .amount-value {
   min-width: 2.5rem;
   padding: 0.35rem 0.75rem;
   text-align: center;
-  color: var(--ea-gold-bright);
+  color: var(--ea-text-color);
   font-weight: 600;
+  font-variant-numeric: tabular-nums;
 }
 
 .name {
   flex: 1 2 auto;
-  font-size: 1.2rem;
+  font-size: 1.05rem;
+  font-weight: 500;
 }
 
 .cost-tag {
   font-size: 0.75rem;
   flex-shrink: 0;
+  color: var(--ea-text-muted-color);
   border: 1px solid var(--ea-surface-border);
-  border-radius: 999px;
+  border-radius: var(--ea-radius-pill);
   padding: 0.1rem 0.5rem;
-  background: var(--ea-surface-100);
+  background: var(--ea-surface-0);
 }
 
 .config-toggle {

--- a/src/components/editor/UpgradePickerDialog.vue
+++ b/src/components/editor/UpgradePickerDialog.vue
@@ -116,8 +116,9 @@ function confirm() {
 .dialog {
   width: min(95vw, 480px);
   background: var(--ea-surface-0);
-  border-radius: 0.5rem;
+  border-radius: var(--ea-radius-md);
   border: 1px solid var(--ea-surface-border);
+  box-shadow: var(--ea-shadow-dialog);
   padding: 1rem;
 }
 
@@ -141,10 +142,14 @@ function confirm() {
   background: var(--ea-surface-0);
 }
 
-.upgrade-option:hover,
+.upgrade-option:hover {
+  border-color: var(--ea-accent-muted);
+  background: var(--ea-surface-50);
+}
+
 .upgrade-option.selected {
-  border-color: var(--ea-primary-color);
-  background: var(--ea-primary-50);
+  border-color: var(--ea-accent);
+  background: var(--ea-accent-subtle);
 }
 
 .option-header {

--- a/src/components/home/CreateListDialog.vue
+++ b/src/components/home/CreateListDialog.vue
@@ -95,8 +95,9 @@ function confirm() {
 .dialog {
   width: min(95vw, 480px);
   background: var(--ea-surface-0);
-  border-radius: 0.5rem;
+  border-radius: var(--ea-radius-md);
   border: 1px solid var(--ea-surface-border);
+  box-shadow: var(--ea-shadow-dialog);
   padding: 1rem;
 }
 

--- a/src/components/home/ListCard.vue
+++ b/src/components/home/ListCard.vue
@@ -96,25 +96,35 @@ const usedPoints = computed(() => {
 }
 
 .action-button {
-  border: 1px solid var(--ea-primary-color);
+  border: 1px solid rgb(31 35 40 / 15%);
   background: var(--ea-primary-color);
   color: var(--ea-primary-contrast-color);
 }
 
+.action-button:hover {
+  background: var(--ea-primary-hover);
+}
+
 .secondary-button {
   border: 1px solid var(--ea-surface-border);
-  background: var(--ea-surface-0);
-  color: inherit;
+  background: var(--ea-surface-50);
+  color: var(--ea-text-color);
+}
+
+.secondary-button:hover {
+  background: #eef1f3;
+  border-color: rgb(31 35 40 / 15%);
 }
 
 .danger-button {
-  border: 1px solid var(--ea-tertiary);
-  background: transparent;
-  color: var(--ea-tertiary);
+  border: 1px solid var(--ea-surface-border);
+  background: var(--ea-surface-50);
+  color: var(--ea-danger-fg);
 }
 
 .danger-button:hover {
-  background: var(--ea-tertiary);
-  color: #1c1b1b;
+  background: var(--ea-danger-emphasis);
+  border-color: var(--ea-danger-emphasis);
+  color: #ffffff;
 }
 </style>

--- a/src/components/print/PrintDetachment.vue
+++ b/src/components/print/PrintDetachment.vue
@@ -222,12 +222,18 @@ const displayGroups = computed<DisplayUnitGroup[]>(() => {
   width: 1.4rem;
   height: 1.4rem;
   margin-right: 0.35rem;
-  border-radius: 999px;
-  background: #000;
-  color: #fff;
+  border-radius: var(--ea-radius-sm);
+  background: var(--ea-accent);
+  color: #ffffff;
   font-size: 0.75rem;
   font-weight: 700;
-  font-family: 'Times New Roman', Times, serif;
+}
+
+@media print {
+  .detachment-number-badge {
+    background: #000;
+    color: #fff;
+  }
 }
 
 .det-points {

--- a/src/components/shared/AppLayout.vue
+++ b/src/components/shared/AppLayout.vue
@@ -3,9 +3,10 @@
 <template>
   <div class="app-layout">
     <header class="app-header no-print">
-      <div class="header-inner header">
+      <div class="header-inner">
         <RouterLink to="/" class="app-title">
-          <span class="app-title-mark">EA</span>Army Builder
+          <span class="app-title-mark">EA</span>
+          <span class="app-title-text">Army Builder</span>
         </RouterLink>
         <nav class="header-nav desktop-only">
           <RouterLink to="/">Lists</RouterLink>
@@ -37,39 +38,44 @@
   display: flex;
   align-items: center;
   flex-shrink: 0;
-  border-bottom: 1px solid var(--ea-tertiary);
+  background: var(--ea-header-bg);
+  border-bottom: 1px solid var(--ea-header-border);
 }
 
 .header-inner {
   width: 100%;
-  max-width: 1200px;
+  max-width: 1280px;
   margin: 0 auto;
   display: flex;
   align-items: center;
-  gap: 1.5rem;
-  padding: 0 2rem;
+  gap: 1rem;
+  padding: 0 1.5rem;
 }
 
 .app-title {
-  font-size: 1.1rem;
-  font-weight: 700;
-  color: var(--ea-tertiary);
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--ea-header-fg);
   text-decoration: none;
-  letter-spacing: 0.06em;
   display: flex;
   align-items: center;
   gap: 0.55rem;
 }
 
+.app-title:hover {
+  text-decoration: none;
+}
+
 .app-title-mark {
   width: 28px;
   height: 28px;
-  border: 2px solid var(--ea-tertiary);
-  border-radius: 2px;
+  border: 1px solid rgb(255 255 255 / 35%);
+  border-radius: 6px;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 13px;
+  font-size: 12px;
+  font-weight: 700;
   letter-spacing: -0.02em;
   flex-shrink: 0;
 }
@@ -80,21 +86,24 @@
 }
 
 .header-nav a {
-  color: inherit;
+  color: var(--ea-header-fg-muted);
   text-decoration: none;
-  opacity: 0.85;
-  font-size: 0.9rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  padding: 0.3rem 0.5rem;
+  border-radius: var(--ea-radius-md);
 }
 
 .header-nav a:hover,
 .header-nav a.router-link-active {
-  opacity: 1;
+  color: var(--ea-header-fg);
+  text-decoration: none;
 }
 
 .app-main {
   flex: 1;
-  padding: 2rem;
-  max-width: 1200px;
+  padding: 1.5rem;
+  max-width: 1280px;
   width: 100%;
   margin: 0 auto;
   padding-bottom: calc(1rem + 4rem);
@@ -132,7 +141,7 @@
 }
 
 .bottom-nav-item.router-link-active {
-  color: var(--ea-primary-color);
+  color: var(--ea-accent);
 }
 
 .desktop-only {

--- a/src/components/shared/ListHeader.vue
+++ b/src/components/shared/ListHeader.vue
@@ -8,43 +8,63 @@ const { list, armyDef, totalPoints } = injected
 </script>
 
 <template>
-  <div class="list-header header surface">
-    <div class="lh-points">{{ totalPoints }} / {{ list?.pointsLimit }} pts</div>
-    <div class="lh-title">{{ list?.name }}</div>
-    <div class="lh-sub">{{ armyDef?.name }}</div>
+  <div class="list-header">
+    <div class="lh-main">
+      <h1 class="lh-title">{{ list?.name }}</h1>
+      <div class="lh-meta">
+        <span class="lh-sub">{{ armyDef?.name }}</span>
+        <span class="lh-dot" aria-hidden="true">·</span>
+        <span class="lh-points">{{ totalPoints }} / {{ list?.pointsLimit }} pts</span>
+      </div>
+    </div>
+    <div id="list-header-cta" class="lh-cta"><slot name="button"></slot></div>
   </div>
-  <div id="list-header-cta" class="button"><slot name="button"></slot></div>
 </template>
 
 <style lang="css" scoped>
 .list-header {
-  padding: 1rem 0;
-  border-color: var(--ea-tertiary);
-  color: var(--ea-tertiary);
-  border-width: 2px 0;
-  border-style: solid;
-  text-align: center;
-  background: transparent;
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+  padding-bottom: 1rem;
   margin-bottom: 1rem;
+  border-bottom: 1px solid var(--ea-surface-border);
+}
+
+.lh-main {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  min-width: 0;
+}
+
+.lh-title {
+  font-size: var(--ea-text-display);
+  font-weight: 600;
+  line-height: 1.2;
+  color: var(--ea-text-color);
+}
+
+.lh-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--ea-text-muted-color);
+  font-size: var(--ea-text-sm);
+}
+
+.lh-dot {
+  color: var(--ea-text-faint-color);
 }
 
 .lh-points {
   font-family: var(--ea-font-mono);
-  font-size: 0.85rem;
-  opacity: 0.85;
+  font-size: 0.8125rem;
 }
 
-.lh-title {
-  font-family: var(--ea-font-display);
-  text-transform: uppercase;
-  font-size: var(--ea-text-display);
-  letter-spacing: 0.03em;
-  line-height: 1.1;
-}
-
-.lh-sub {
-  text-transform: uppercase;
-  font-size: 0.78rem;
-  letter-spacing: 0.12em;
+.lh-cta {
+  flex-shrink: 0;
 }
 </style>

--- a/src/components/shared/ListTabBar.vue
+++ b/src/components/shared/ListTabBar.vue
@@ -60,8 +60,8 @@ const route = useRoute()
 }
 
 .tab-item.active {
-  color: var(--ea-primary-color);
-  border-bottom-color: var(--ea-primary-color);
-  font-weight: 500;
+  color: var(--ea-text-color);
+  border-bottom-color: #fd8c73;
+  font-weight: 600;
 }
 </style>

--- a/src/components/shared/PointsBadge.vue
+++ b/src/components/shared/PointsBadge.vue
@@ -20,15 +20,18 @@ const isOverBudget = computed(() => props.limit !== undefined && props.used > pr
   display: inline-flex;
   align-items: center;
   border: 1px solid var(--ea-surface-border);
-  border-radius: 999px;
-  padding: 0.1rem 0.5rem;
+  border-radius: var(--ea-radius-pill);
+  padding: 0.05rem 0.6rem;
   font-size: 0.75rem;
-  background: var(--ea-surface-100);
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
+  color: var(--ea-text-muted-color);
+  background: var(--ea-surface-0);
 }
 
 .points-badge--warn {
-  color: #9a3412;
-  border-color: #fdba74;
-  background: #ffedd5;
+  color: var(--ea-attention-fg);
+  border-color: var(--ea-attention-border);
+  background: var(--ea-attention-subtle);
 }
 </style>

--- a/src/components/shared/ValidationWarnings.vue
+++ b/src/components/shared/ValidationWarnings.vue
@@ -24,11 +24,13 @@ const severity = computed(() => {
 
 <style scoped>
 .validation-message {
-  padding: 0.5rem 0.75rem;
-  border-radius: var(--ea-radius-sm);
+  padding: 0.5rem 0.85rem;
+  border-radius: var(--ea-radius-md);
   font-size: 0.875rem;
   margin-bottom: 1rem;
-  background: var(--ea--surface-2);
+  border: 1px solid var(--ea-surface-border);
+  background: var(--ea-surface-0);
+  color: var(--ea-text-color);
   display: flex;
   align-items: center;
   gap: 0.5rem;
@@ -41,24 +43,36 @@ const severity = computed(() => {
   flex-shrink: 0;
 }
 
+.severity-success {
+  border-color: rgb(74 194 107 / 40%);
+  background: var(--ea-success-subtle);
+}
+
 .severity-success .dot {
-  background: var(--ea-tertiary);
+  background: var(--ea-success-emphasis);
 }
 
-.severity-warn,
+.severity-warn {
+  border-color: var(--ea-attention-border);
+  background: var(--ea-attention-subtle);
+}
+
+.severity-warn .dot {
+  background: var(--ea-attention-fg);
+}
+
 .severity-error {
-  background: var(--ea-primary);
-  color: var(--ea-primary-contrast-color);
+  border-color: rgb(255 129 130 / 60%);
+  background: var(--ea-danger-subtle);
 }
 
-.severity-warn .dot,
 .severity-error .dot {
-  background: var(--ea-primary-contrast-color);
+  background: var(--ea-danger-emphasis);
 }
 
 .issue-count {
   margin-left: auto;
   font-size: 0.75rem;
-  opacity: 0.8;
+  color: var(--ea-text-muted-color);
 }
 </style>


### PR DESCRIPTION
## Summary

Reworks the app's layout and styling from the dark "tactical command" theme to a clean, natural design inspired by GitHub's [Primer](https://primer.style) design system. The design is token-driven, so most of the change lives in `main.css`; the rest fixes components that hardcoded dark-theme assumptions or reused brand colors for semantics.

The treatment is applied across **every page**: Home, the list editor, the read-only View, the Reference and per-army tables, the unit GPR chart, all dialogs, and the 404/empty states.

## What changed

**Design tokens (`src/assets/main.css`)**
- Light canvas (`#f6f8fa`) with white cards, Primer border (`#d0d7de`) and text (`#1f2328` / muted `#59636e`) palette
- Blue accent (`#0969da`) for links and selection, green (`#1f883d`) for primary actions, plus semantic success/danger/attention and `accent.subtle`/`surface-200` tokens
- System font stack; headings are no longer uppercase/serif/gold
- Primer-style form controls with focus rings, restrained shadows, 6px radii

**Layout & shared components**
- `AppLayout`: GitHub-style dark global nav bar over a light content area
- `ListHeader`: clean page subhead replacing the gold uppercase band
- `ListTabBar`: underline-nav with the orange selected indicator
- `PointsBadge`: Primer Label/Counter; `ValidationWarnings`: semantic flash messages
- Buttons: green primary, subtle default, red danger across cards, editor, and dialogs

**Editor, dialogs & tables**
- Detachment cards and number badges aligned to the accent palette
- Fixed the unit-count stepper (it referenced removed gold tokens and rendered invisible) — now a Primer segmented control
- Dialogs get proper elevation and blue-accent selection states
- View-page units table header background restored via `--ea-surface-200`
- Detachment number badge stays black under `@media print`

## Verification
- `npm run build` ✅ · `npm run test:unit` ✅ · `npm run lint` ✅ (one pre-existing, unrelated warning in `AppliedUpgradePanel.vue`)
- Drove the app with Chromium and screenshotted Home, create dialog, editor (with steppers and applied upgrades), Add Detachment + Upgrade Picker dialogs, View, Reference, Army view, GPR chart, and print emulation — all render cohesively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01256GVfWdLJbT35zFsSHAtV)_