### PR TITLE
Fill in special rule descriptions for Legiones Astartes unit traits

### DIFF
--- a/src/data/special-rules.json
+++ b/src/data/special-rules.json
@@ -15,7 +15,52 @@
     },
     {
         "title": "Thick Rear Armour",
-        "paragraphs": []
+        "paragraphs": [
+            "Most vehicles carry their heaviest protection at the front and are more vulnerable to attacks that strike their flanks or rear. Units with thick rear armour are protected by armour that is as strong at the back as it is at the front. Because of this, an enemy unit attacking a unit with thick rear armour in an assault does not receive the normal +1 to hit bonus for attacking the target in the rear."
+        ]
+    },
+    {
+        "title": "Walker",
+        "paragraphs": [
+            "Some vehicles and War Engines move on articulated legs rather than tracks, wheels or anti-grav motors; these units are referred to as walkers. Walkers are able to pick their way over obstacles that would stop other vehicles, and so treat difficult ground as if it were clear terrain, moving through it at their full speed. They must still take a dangerous terrain test as normal if they move over dangerous terrain."
+        ]
+    },
+    {
+        "title": "Skimmer",
+        "paragraphs": [
+            "Skimmers use anti-grav motors that allow them to skim over the ground and any obstacles in their path. Skimmers may move over any type of terrain and over any other units, whether friend or enemy, with no penalty, and ignore the effects of difficult and dangerous terrain. A skimmer must, however, finish its move in a position where it could be deployed normally, and may not, for example, end its move on top of impassable terrain or another unit.",
+            "A skimmer may end its move \"popped up\" so that it can see and shoot over intervening terrain that would otherwise block its line of fire. While it is popped up the skimmer may be shot at by any enemy unit that could draw a line of fire to it, and may be targeted by anti-aircraft fire as if it were an aircraft."
+        ]
+    },
+    {
+        "title": "Jump Packs",
+        "paragraphs": [
+            "Troops equipped with jump packs are able to make great bounding leaps across the battlefield. A unit with a jump pack may make a special move of up to 30cms instead of its normal move. When it makes this special move the unit may move over enemy units and any type of terrain freely, in the same way that a skimmer can, and it ignores the effects of dangerous terrain. The unit must finish its move in a position where it could be deployed normally."
+        ]
+    },
+    {
+        "title": "Mounted",
+        "paragraphs": [
+            "Mounted units, such as bikes and cavalry, combine some of the speed and mobility of a vehicle with the flexibility of infantry. Mounted units are treated as infantry for all rules purposes, but are fast moving and so are able to cover ground far more quickly than troops on foot. In return for their speed they are less able to make use of cover and may not enter or move through terrain that would halt a mounted advance."
+        ]
+    },
+    {
+        "title": "Scout",
+        "paragraphs": [
+            "Scout units are specially trained to operate independently of the rest of their force, reconnoitring the battlefield and screening the advance of the main body of troops. A formation that includes one or more scout units may be set up as a garrison at the start of the game, allowing it to deploy further forward than normal troops. In addition, scout units have a zone of control that extends out to 15cms, rather than the usual 5cms, allowing them to control a far greater area of the battlefield and slow the enemy's advance."
+        ]
+    },
+    {
+        "title": "Invulnerable Save",
+        "paragraphs": [
+            "Some units are protected by force fields, arcane wards or other exotic defences that can turn aside even the most powerful blows. A unit with an invulnerable save is allowed to take its armour saving throw against any hit that strikes it, even from attacks such as macro-weapons that would normally deny a save. Unlike reinforced armour, this protection works against every type of attack, but the save itself is taken using the unit's normal armour value."
+        ]
+    },
+    {
+        "title": "Know no fear",
+        "paragraphs": [
+            "Space Marines are conditioned to feel no fear and to fight on against impossible odds where lesser warriors would break and run. To represent this, a broken Space Marine formation is allowed to regroup even if there are enemy units within 15cms of it, although it may only be given a Hold order on the turn that it does so. In addition, Space Marine formations remove one extra Blast marker than normal whenever they successfully regroup."
+        ]
     },
     {
         "title": "Commander",


### PR DESCRIPTION
## Summary

Went through every unit trait in `src/data/armies/legiones-astartes.json` and filled in the matching special-rule descriptions in `src/data/special-rules.json`. Rules are matched to traits by exact `title` (see `StaticJsonArmyLoader.enrichArmy`), so the titles below match the trait strings exactly.

### Traits found in `legiones-astartes.json`

| Trait | Status before | Action |
|---|---|---|
| Reinforced Armour | already filled | unchanged |
| Teleport | already filled | unchanged |
| Thick Rear Armour | **present but empty** | filled in |
| Walker | missing | **added** |
| Skimmer | missing | **added** |
| Jump Packs | missing | **added** |
| Mounted | missing | **added** |
| Scout | missing | **added** |
| Invulnerable Save | missing | **added** |
| Know no fear | missing | **added** |
| `PLANET_FALL` | missing | **left untouched** (see note) |

Descriptions follow the Epic: Armageddon ruleset and match the prose/citation style of the existing entries. `npm run validate` passes (all army files + `special-rules.json`).

### ⚠️ Important note on sourcing

The task asked me to source descriptions from `https://tp.net-armageddon.org/rules/`, but **that host (and every external host) is blocked by this environment's egress network policy** — the proxy gateway returns a hard 403 policy denial, so I could not fetch the live page. I wrote these from the Epic: Armageddon ruleset (the same ruleset that site hosts), matching the verbatim style of the entries already in the file.

Please **verify the wording against the live site in review**, particularly the entries where exact mechanics are easiest to get slightly wrong:

- **Know no fear** – army-list (Codex Astartes) rule rather than a core-rulebook ability; double-check the regroup/Blast-marker specifics.
- **Thick Rear Armour** – confirm the rear-attack to-hit interaction matches the list.
- **Scout** – confirm the zone-of-control / garrison specifics.
- **Invulnerable Save** – not a standard core-rules ability; appears only on the Deredeo Dreadnought. Confirm this is how the list intends it.

### `PLANET_FALL`

This value (only on Thunderhawk Gunship and Storm Eagle Attack Ship) looks like a placeholder/enum-style string rather than a finished display trait, so I did **not** invent a rule for it. If you'd like, I can add a proper "Planetfall" rule and rename the trait in the unit data to match — just say the word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DS1XRJpUCxSc226W8uQakE)_