### PR TITLE
Fix base unit counts stuck when both a default count and min/max are set

### DIFF
--- a/src/components/editor/BaseUnitsPanel.vue
+++ b/src/components/editor/BaseUnitsPanel.vue
@@ -36,13 +36,13 @@ function getDetachmentUnit(unitName: string) {
 function getMin(unitName: string): number {
   const uc = getDetachmentUnit(unitName)
   if (!uc) return 0
-  return 'min' in uc ? uc.min : uc.count
+  return uc.min ?? uc.count ?? 0
 }
 
 function getMax(unitName: string): number {
   const uc = getDetachmentUnit(unitName)
   if (!uc) return 99
-  return 'max' in uc ? uc.max : uc.count
+  return uc.max ?? uc.count ?? 99
 }
 
 function getUnitDef(unitName: string) {

--- a/src/data/armies/playwright-test-army.json
+++ b/src/data/armies/playwright-test-army.json
@@ -13,6 +13,12 @@
           "unitName": "Test Tank",
           "min": 1,
           "max": 3
+        },
+        {
+          "unitName": "Test Predator",
+          "count": 3,
+          "min": 3,
+          "max": 6
         }
       ],
       "availableUpgrades": ["Test Support Upgrade", "Test Retrofit", "Test Commander"],
@@ -102,6 +108,23 @@
         "trainingSetSize": 12,
         "modelKernel": "RBF"
       }
+    },
+    {
+      "name": "Test Predator",
+      "cost": 80,
+      "type": "AV",
+      "speed": "20cm",
+      "armour": "4+",
+      "cc": "6+",
+      "ff": "5+",
+      "weaponSlots": [
+        {
+          "kind": "fixed",
+          "weaponName": "Predator Cannon",
+          "range": "45cm",
+          "firepower": "AT5+ AP5+"
+        }
+      ]
     },
     {
       "name": "Elite Test Tank",

--- a/src/entities/army.ts
+++ b/src/entities/army.ts
@@ -123,10 +123,13 @@ export function groupUnitsForReference(units: UnitDef[]): UnitReferenceGroup[] {
 
 // ─── Detachment / upgrade definitions ────────────────────────────────────────
 
-/** Represents a unit count that may be fixed or a variable range */
-export type UnitCount =
-  | { unitName: string; count: number }
-  | { unitName: string; min: number; max: number }
+/** Represents a unit count that may be fixed, a variable range, or both (a default count adjustable within min/max) */
+export type UnitCount = {
+  unitName: string
+  count?: number
+  min?: number
+  max?: number
+}
 
 export interface ReplaceSpec {
   fromUnitName: string

--- a/src/infrastructure/armySchema.ts
+++ b/src/infrastructure/armySchema.ts
@@ -81,10 +81,16 @@ export const UnitDefSchema = z.object({
 
 // ─── Detachment / upgrade definitions ────────────────────────────────────────
 
-export const UnitCountSchema = z.union([
-  z.object({ unitName: z.string(), count: z.number() }),
-  z.object({ unitName: z.string(), min: z.number(), max: z.number() }),
-])
+export const UnitCountSchema = z
+  .object({
+    unitName: z.string(),
+    count: z.number().optional(),
+    min: z.number().optional(),
+    max: z.number().optional(),
+  })
+  .refine((u) => u.count !== undefined || (u.min !== undefined && u.max !== undefined), {
+    message: 'UnitCount requires either count or both min and max',
+  })
 
 export const ReplaceSpecSchema = z.object({
   fromUnitName: z.string(),

--- a/src/use-cases/list/EntryUseCases.ts
+++ b/src/use-cases/list/EntryUseCases.ts
@@ -41,8 +41,11 @@ function clampBaseUnitCount(
   const detachment = armyDef.detachments.find((d) => d.name === detachmentName)
   const unitCount = detachment?.units.find((u) => u.unitName === unitName)
   if (!unitCount) return newCount
-  if ('count' in unitCount) return unitCount.count
-  return Math.max(unitCount.min, Math.min(unitCount.max, newCount))
+  const { min, max, count } = unitCount
+  if (min !== undefined && max !== undefined) {
+    return Math.max(min, Math.min(max, newCount))
+  }
+  return count ?? newCount
 }
 
 function getListOrThrow(repo: ListRepository, listId: string): ArmyList {
@@ -74,7 +77,7 @@ export function addEntry(
   if (!detDef) throw new Error(`Detachment not found: ${detachmentName}`)
 
   const baseUnits: UnitTypeEntry[] = detDef.units.map((uc) => {
-    const count = 'count' in uc ? uc.count : uc.min
+    const count = uc.count ?? uc.min ?? 0
     return {
       unitName: uc.unitName,
       instances: makeInstances(uc.unitName, count, armyDef),

--- a/tests/playwright/list-mutations.spec.ts
+++ b/tests/playwright/list-mutations.spec.ts
@@ -130,6 +130,26 @@ test.describe('Unit Counts and Weapon Selections', () => {
     await expect(card).toContainText('1 Test Tank')
   })
 
+  test('allows incrementing a hybrid count/min/max base unit up to its max', async ({ page }) => {
+    const card = detachmentCard(page, 'Mutable Detachment')
+    const predatorPanel = card
+      .locator('details')
+      .first()
+      .locator('.unit')
+      .filter({ hasText: 'Test Predator' })
+      .first()
+    const increaseButton = predatorPanel.getByRole('button', {
+      name: 'Increase Test Predator count',
+    })
+
+    await expect(predatorPanel.locator('.amount-value')).toHaveText('3')
+    await expect(increaseButton).toBeEnabled()
+
+    await increaseButton.click()
+    await expect(predatorPanel.locator('.amount-value')).toHaveText('4')
+    await expect(card).toContainText('4 Test Predator')
+  })
+
   test('selects a weapon for a base unit', async ({ page }) => {
     const card = detachmentCard(page, 'Mutable Detachment')
     const baseTankPanel = card


### PR DESCRIPTION
## Summary
- `UnitCountSchema` used a `z.union` of `{count}` / `{min, max}`. Zod tries union members in order and strips unrecognized keys from the first match, so units with all three fields (e.g. Predator: `count: 3, min: 3, max: 6`) silently lost `min`/`max` at parse time — long before the UI or domain logic ran. This locked the base unit count to its starting value and disabled the "+" control, even though units like the Predator, Terminator Squad, Sicaran/Kratos Battle Tanks are meant to be adjustable up to `max`.
- `UnitCountSchema`/`UnitCount` now model count/min/max as a single object with optional fields, so all three survive parsing together.
- Fixed `clampBaseUnitCount`'s short-circuit in `EntryUseCases.ts` (was returning the fixed `count` before ever checking min/max) and updated the few call sites that relied on the old discriminated-union shape (`BaseUnitsPanel.vue`, `addEntry`).

## Test plan
- [x] Added a `Test Predator` (`count: 3, min: 3, max: 6`) unit to the Playwright fixture army and a new e2e test asserting the "+" control is enabled and increments past the starting count — confirmed it failed before the fix (button rendered disabled) and passes after.
- [x] `npm run validate` — all army JSON files still parse correctly.
- [x] `npm run test:unit` and `npm run test:e2e` — full suite passes (21/21 e2e), no regressions.
- [x] `npx vue-tsc -b --noEmit` — clean.
- [ ] Manually verify in the running app: add a "Predators Detachment" and confirm the Predator count can be incremented from 3 up to 6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)