### PR TITLE
docs: update architecture & routing docs, add GPR transparency & validation

### DIFF
--- a/.github/agents/playwright-typescript.md
+++ b/.github/agents/playwright-typescript.md
@@ -21,7 +21,7 @@ applyTo: '**'
 
 ### File Organization
 
-- **Location**: Store all test files in the `tests/` directory.
+- **Location**: Store all test files in the `tests/playwright/` directory.
 - **Naming**: Use the convention `<feature-or-page>.spec.ts` (e.g., `login.spec.ts`, `search.spec.ts`).
 - **Scope**: Aim for one test file per major application feature or page.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,15 +8,17 @@ A mobile-first web SPA for building army lists for the Epic Armageddon tabletop 
 
 ## Tech stack
 
-| Concern          | Technology                                                |
-| ---------------- | --------------------------------------------------------- |
-| Build tool       | Vite                                                      |
-| Framework        | Vue 3 (`<script setup>` + Composition API)                |
-| Language         | TypeScript (strict mode)                                  |
-| State management | Pinia (though reactive state lives mostly in composables) |
-| UI components    | Native Vue/HTML components                                |
-| Routing          | Vue Router 4                                              |
-| ID generation    | `uuid` (`v4`)                                             |
+| Concern           | Technology                                                 |
+| ----------------- | ----------------------------------------------------------- |
+| Build tool        | Vite                                                       |
+| Framework         | Vue 3 (`<script setup>` + Composition API)                |
+| Language          | TypeScript (strict mode)                                  |
+| State management  | Pinia (though reactive state lives mostly in composables) |
+| UI components     | Native Vue/HTML components                                |
+| Routing           | Vue Router 4                                               |
+| ID generation     | `uuid` (`v4`)                                              |
+| Utilities         | `@vueuse/core`                                             |
+| Schema validation | `zod` (army JSON validation, see `npm run validate`)       |
 
 ## Architecture: hexagonal (ports & adapters)
 
@@ -61,15 +63,15 @@ components → composables → use-cases → ports ← infrastructure
 
 Describes what choices are available: detachments, upgrades, unit definitions, weapon definitions, army-level restrictions (e.g. max 30% of points on Support detachments).
 
-- `DetachmentDef` — name, group, mandatory units (`UnitCount` — fixed count or min/max range), available upgrades, restrictions
-- `UpgradeDef` — discriminated union: `{ type: 'add', adds: AddSpec[] }` or `{ type: 'replace', replaces: ReplaceSpec }`
-- `UnitDef` — name, cost, type, speed, armour, cc, ff, `weaponSlots: WeaponSlot[]`, transportType, transportCapacity
-- `WeaponSlot` — discriminated union: `{ kind: 'fixed', weaponName, count? }` or `{ kind: 'choice', choices: WeaponOption[] }`
+- `DetachmentDef` — name, group, mandatory units (`UnitCount` — fixed count or min/max range), available upgrades, restrictions (e.g. `max_per_list`)
+- `UpgradeDef` — discriminated union: `{ type: 'add', adds: AddSpec[] }`, `{ type: 'replace', replaces: ReplaceSpec }`, or `{ type: 'character', characterNames: string[] }`
+- `UnitDef` — name, cost, type, speed, armour, cc, ff, `weaponSlots: WeaponSlot[]`, optional `transportation: { cost?, type?, capacity?, capabilities? }`, optional `gprTrainingInfo` (see GPR transparency below)
+- `WeaponSlot` — discriminated union: `{ kind: 'fixed', weaponName, range, firepower, count? }` or `{ kind: 'choice', choices: WeaponOption[] }`
 
 ### `ArmyList` (user-created, persisted)
 
 - `Entry` — one detachment instance: `id`, `detachmentName`, `baseUnits: UnitTypeEntry[]`, `appliedUpgrades: AppliedUpgrade[]`
-- `AppliedUpgrade` — discriminated union: `{ type: 'add', addedUnits: UnitTypeEntry[] }` or `{ type: 'replace', replacedCount, replacingUnits: UnitTypeEntry }`
+- `AppliedUpgrade` — discriminated union: `{ type: 'add', addedUnits: UnitTypeEntry[] }`, `{ type: 'replace', replacedCount, replacingUnits: UnitTypeEntry }`, or `{ type: 'character', chosenCharacterName: string | null }`
 - `UnitTypeEntry` — `{ unitName, instances: UnitInstance[] }` — `instances.length` is the effective count
 - `UnitInstance` — `{ weaponSelections: WeaponSelection[] }` — one entry per choice weapon slot; units with no choice slots have an empty array
 
@@ -89,20 +91,31 @@ Weapon selections are **per individual unit instance** — each model in a forma
 
 ## Routes
 
-| Path          | View         | Description                           |
-| ------------- | ------------ | ------------------------------------- |
-| `/`           | `HomeView`   | List of saved army lists              |
-| `/edit/:id`   | `EditorView` | Full list editor                      |
-| `/view/:id`   | `PrintView`  | Printer-friendly view with unit stats |
-| `/army/:slug` | `ArmyView`   | Human-readable army reference         |
+| Path                                 | View                 | Description                                         |
+| ------------------------------------- | -------------------- | ---------------------------------------------------- |
+| `/`                                   | `HomeView`           | List of saved army lists                             |
+| `/army/:slug`                         | `ArmyView`           | Human-readable army reference                        |
+| `/:id`                                | `ListLayout`         | Shell for a single list; redirects to `view`         |
+| `/:id/view`                           | `PrintView`          | Printer-friendly view with unit stats                |
+| `/:id/edit`                           | `EditorView`         | Full list editor                                     |
+| `/:id/reference`                      | `ListReferenceView`  | Army reference scoped to the list's army             |
+| `/:id/reference/unit/:unitName/gpr`   | `UnitGprView`        | GPR transparency view for a single unit (see below)  |
+| `/:pathMatch(.*)*`                    | `NotFoundView`       | 404 fallback                                         |
+
+`ListLayout` instantiates `useListEditor(id)` once and `provide`s it under `listEditorKey`; the four child views and their components `inject(listEditorKey)` rather than re-instantiating the editor composable.
+
+### GPR transparency
+
+`UnitDef.gprTrainingInfo` (optional) holds the output of a Gaussian Process Regression model used to sanity-check a unit's hand-authored point cost against stat-derived predictions: `predictedMean`, `uncertainty`, `score`, `quality`, `topNearestNeighbours`, `contributingPriceValues`, `trainingSetSize`, `modelKernel`. `UnitGprView` (using `components/army/GprChart.vue`) renders this for army-reference users; units without training data show an empty-state instead of erroring.
 
 ---
 
 ## Adding a new army
 
-1. Create `src/data/armies/<kebab-case-name>.json` following the `ArmyDef` schema in `src/entities/army.ts`
-2. Import it in `src/infrastructure/StaticJsonArmyLoader.ts` and add it to the `armies` array
-3. The new army will automatically appear in the "New List" dialog
+1. Create `src/data/armies/<kebab-case-name>.json` matching `RawArmyDefSchema` in `src/infrastructure/armySchema.ts` (the raw, on-disk shape — a subset of `ArmyDef`; `unitSpecialRules` is computed at load time, not authored)
+2. Import it in `src/infrastructure/StaticJsonArmyLoader.ts` and add it to the `armies` array (it gets parsed through `RawArmyDefSchema` and enriched there)
+3. Run `npm run validate` (`scripts/validate-armies.ts`) to check the new file and `src/data/special-rules.json` against their zod schemas before committing
+4. The new army will automatically appear in the "New List" dialog
 
 ### Army JSON structure
 
@@ -117,10 +130,11 @@ Weapon selections are **per individual unit instance** — each model in a forma
   ],
   "detachments": [...],
   "upgrades": [...],
-  "units": [...],
-  "weapons": [...]
+  "units": [...]                     // weapon profiles live inline on each unit's weaponSlots, not a separate top-level array
 }
 ```
+
+Unit special rules are resolved against the shared `src/data/special-rules.json` file by matching each unit's `specialRuleNames` (or legacy `traits`) to a rule `title`; the matched set becomes `ArmyDef.unitSpecialRules`.
 
 ---
 

--- a/.github/workflows/feature-request-enrichment.md
+++ b/.github/workflows/feature-request-enrichment.md
@@ -47,14 +47,15 @@ The project is a Vue 3 + TypeScript SPA with a **hexagonal (ports & adapters) ar
 - `components/` — UI layer, calls composables only
 - `infrastructure/` — driven adapters (localStorage, static JSON army data)
 - `data/armies/` — static JSON army definition files
-- Routes: `/` (HomeView — list of saved armies), `/edit/:id` (EditorView), `/view/:id` (PrintView), `/army/:slug` (ArmyView)
+- Routes: `/` (HomeView — list of saved armies), `/army/:slug` (ArmyView), `/:id` (ListLayout shell) with children `/:id/view` (PrintView), `/:id/edit` (EditorView), `/:id/reference` (ListReferenceView), `/:id/reference/unit/:unitName/gpr` (UnitGprView)
 
 Key domain concepts:
 - **ArmyList** — a named list with a points limit, containing multiple `Entry` (detachment instances)
-- **Entry** — one detachment: base units, applied upgrades (add/replace type)
+- **Entry** — one detachment: base units, applied upgrades (add/replace/character type)
 - **WeaponSelections** are **per individual unit instance** — each model independently tracks its chosen weapon
 - All data is auto-saved to `localStorage`
-- Army definitions are static JSON files; adding a new army requires a JSON file + one import in `StaticJsonArmyLoader.ts`
+- Army definitions are static JSON files validated against zod schemas (`npm run validate`); adding a new army requires a JSON file + one import in `StaticJsonArmyLoader.ts`
+- Units may carry `gprTrainingInfo` (Gaussian Process Regression data) used to sanity-check hand-authored point costs, surfaced via the GPR transparency view
 - End-to-end tests use Playwright (`npm run test:e2e`); mutation tests use `playwright-test-army.json`
 
 ## Trigger context

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+.github/copilot-instructions.md

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -1,0 +1,1 @@
+../.github/agents/playwright-typescript.md


### PR DESCRIPTION
## Summary
Updated documentation to reflect recent architectural changes, new features, and improved development workflows. Added schema validation guidance and documented the GPR (Gaussian Process Regression) transparency feature for unit cost sanity-checking.

## Key Changes

- **Tech stack**: Added `@vueuse/core` and `zod` to documented dependencies; clarified `zod` is used for army JSON validation
- **Data structures**: 
  - Updated `DetachmentDef`, `UpgradeDef`, `UnitDef`, and `WeaponSlot` documentation to reflect new fields (`max_per_list` restrictions, `character` upgrade type, inline weapon profiles, optional `transportation` and `gprTrainingInfo`)
  - Updated `AppliedUpgrade` to include `character` type
- **Routing**: Restructured routes to reflect new nested layout pattern:
  - Changed from flat `/edit/:id`, `/view/:id` to nested `/:id/*` with `ListLayout` shell
  - Added `/:id/reference` (ListReferenceView) and `/:id/reference/unit/:unitName/gpr` (UnitGprView)
  - Added `/:pathMatch(.*)*` 404 fallback
  - Documented `ListLayout` provider pattern for shared editor state
- **GPR transparency**: Added new section documenting `UnitDef.gprTrainingInfo` structure and `UnitGprView` rendering
- **Army validation**: Updated "Adding a new army" workflow to include `npm run validate` step and clarified distinction between `RawArmyDefSchema` (on-disk) and `ArmyDef` (enriched)
- **Special rules**: Documented that unit special rules are resolved from shared `src/data/special-rules.json` at load time
- **Test organization**: Corrected test file location from `tests/` to `tests/playwright/`
- **Agent hints**: Added `CLAUDE.md` files to guide AI assistants to relevant documentation

## Notable Details

- Weapon profiles now live inline on `UnitDef.weaponSlots` rather than in a separate top-level array
- `WeaponSlot` now includes `range` and `firepower` fields in fixed slots
- `UnitDef.transportation` is now optional with nested `cost`, `type`, `capacity`, and `capabilities` fields
- Army JSON validation is now a required pre-commit step via `npm run validate`

https://claude.ai/code/session_01TBMhzQViGLuZepX6C6fpdg