### PR TITLE
Fix text wrapping in special rules table descriptions

### DIFF
--- a/src/components/army/SpecialRulesTable.vue
+++ b/src/components/army/SpecialRulesTable.vue
@@ -18,9 +18,17 @@ defineProps<{
       <tbody>
         <tr v-for="rule in rules" :key="rule.title">
           <td>{{ rule.title }}</td>
-          <td>{{ rule.paragraphs.length > 0 ? rule.paragraphs.join(' ') : '—' }}</td>
+          <td class="rule-description">
+            {{ rule.paragraphs.length > 0 ? rule.paragraphs.join(' ') : '—' }}
+          </td>
         </tr>
       </tbody>
     </table>
   </div>
 </template>
+
+<style scoped>
+.army-reference-table .army-reference-table__native-table td.rule-description {
+  white-space: normal;
+}
+</style>

--- a/src/components/army/SpecialRulesTable.vue
+++ b/src/components/army/SpecialRulesTable.vue
@@ -19,7 +19,8 @@ defineProps<{
         <tr v-for="rule in rules" :key="rule.title">
           <td>{{ rule.title }}</td>
           <td class="rule-description">
-            {{ rule.paragraphs.length > 0 ? rule.paragraphs.join(' ') : '—' }}
+            <p v-for="(paragraph, index) in rule.paragraphs" :key="index">{{ paragraph }}</p>
+            <template v-if="rule.paragraphs.length === 0">—</template>
           </td>
         </tr>
       </tbody>
@@ -30,5 +31,13 @@ defineProps<{
 <style scoped>
 .army-reference-table .army-reference-table__native-table td.rule-description {
   white-space: normal;
+}
+
+.rule-description p:not(:last-child) {
+  margin-bottom: 0.5rem;
+}
+
+.rule-description p {
+  margin-top: 0;
 }
 </style>


### PR DESCRIPTION
## Summary

Fixes text overflow in the special rules table by enabling normal text wrapping for rule descriptions.

## Changes

- Added `rule-description` class to the description cell in `SpecialRulesTable.vue`
- Added scoped CSS rule to set `white-space: normal` on rule description cells, allowing long text to wrap instead of overflowing

## Details

Rule descriptions in the special rules table were not wrapping properly, causing text to overflow horizontally. This change applies the `rule-description` class to the description `<td>` and adds a scoped style rule that explicitly sets `white-space: normal` to restore default text wrapping behavior.

https://claude.ai/code/session_01MrhCBQAZbCsyTaH8ozwnYE