### PR TITLE
Show minimum points cost for each detachment in the add detachment dialog

### DIFF
--- a/src/components/editor/AddDetachmentDialog.vue
+++ b/src/components/editor/AddDetachmentDialog.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
 import type { ArmyDef, DetachmentDef, UnitCount } from '@/entities/army'
+import { detachmentMinCost } from '@/entities/points'
 
 const visible = defineModel<boolean>('visible', { default: false })
 
@@ -34,6 +35,10 @@ const filteredDetachments = computed(() => {
   if (!activeGroup.value) return detachmentOptions
   return detachmentOptions.filter((det) => det.group === activeGroup.value)
 })
+
+function minCost(det: DetachmentDef): number {
+  return detachmentMinCost(det, props.armyDef)
+}
 
 function describeUnits(det: DetachmentDef): string {
   return det.units
@@ -91,6 +96,7 @@ function confirm() {
             >
               <div class="det-header">
                 <span class="det-name">{{ det.name }}</span>
+                <span class="det-min-cost">{{ minCost(det) }} pts</span>
                 <span class="group-tag">{{ det.group }}</span>
               </div>
               <p class="det-units">{{ describeUnits(det) }}</p>
@@ -200,6 +206,12 @@ function confirm() {
 .det-name {
   font-weight: 600;
   flex: 1;
+}
+
+.det-min-cost {
+  font-size: 0.8rem;
+  color: var(--ea-text-muted-color);
+  white-space: nowrap;
 }
 
 .group-tag {

--- a/src/entities/points.ts
+++ b/src/entities/points.ts
@@ -136,18 +136,26 @@ export function calculateAppliedUpgradePoints(upgrade: AppliedUpgrade, armyDef: 
 
 // ─── Detachment-level cost ────────────────────────────────────────────────────
 
+/** Returns a unit's base cost plus the cheapest option for each of its choice weapon slots */
+function unitMinCost(def: UnitDef): number {
+    return def.weaponSlots.reduce((sum, slot) => {
+        if (slot.kind !== 'choice') return sum
+        const cheapest = Math.min(...slot.choices.map((c) => c.additionalCost))
+        return sum + cheapest
+    }, def.cost)
+}
+
 /**
  * Returns the minimum points cost to field a detachment: the cost of its
  * mandatory base units at their minimum count (fixed `count`, or `min` for
- * variable-count units), with all choice weapon slots defaulted to their
- * cheapest (0 additional cost) option.
+ * variable-count units), with each choice weapon slot taking its cheapest option.
  */
 export function detachmentMinCost(detachmentDef: DetachmentDef, armyDef: ArmyDef): number {
     return detachmentDef.units.reduce((sum, uc) => {
         const def = findUnitDef(armyDef, uc.unitName)
         if (!def) return sum
         const minCount = uc.count ?? uc.min ?? 0
-        return sum + def.cost * minCount
+        return sum + unitMinCost(def) * minCount
     }, 0)
 }
 

--- a/src/entities/points.ts
+++ b/src/entities/points.ts
@@ -1,4 +1,4 @@
-import type { ArmyDef, UnitDef, UpgradeDef, WeaponSlot } from './army'
+import type { ArmyDef, DetachmentDef, UnitDef, UpgradeDef, WeaponSlot } from './army'
 import type { AppliedUpgrade, ArmyList, Entry, UnitInstance, UnitTypeEntry } from './list'
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -132,6 +132,23 @@ export function calculateAppliedUpgradePoints(upgrade: AppliedUpgrade, armyDef: 
     }
     // 'add' type
     return upgrade.addedUnits.reduce((sum, ute) => sum + unitTypeEntryCost(ute, armyDef), 0)
+}
+
+// ─── Detachment-level cost ────────────────────────────────────────────────────
+
+/**
+ * Returns the minimum points cost to field a detachment: the cost of its
+ * mandatory base units at their minimum count (fixed `count`, or `min` for
+ * variable-count units), with all choice weapon slots defaulted to their
+ * cheapest (0 additional cost) option.
+ */
+export function detachmentMinCost(detachmentDef: DetachmentDef, armyDef: ArmyDef): number {
+    return detachmentDef.units.reduce((sum, uc) => {
+        const def = findUnitDef(armyDef, uc.unitName)
+        if (!def) return sum
+        const minCount = uc.count ?? uc.min ?? 0
+        return sum + def.cost * minCount
+    }, 0)
 }
 
 // ─── List-level cost ─────────────────────────────────────────────────────────

--- a/tests/playwright/list-mutations.spec.ts
+++ b/tests/playwright/list-mutations.spec.ts
@@ -7,6 +7,26 @@ import {
   resetLists,
 } from './helpers'
 
+test.describe('Add Detachment Dialog', () => {
+  test.beforeEach(async ({ page }) => {
+    await createPlaywrightTestList(page, 'Min Cost Test')
+    await page.getByRole('button', { name: 'Add Detachment' }).click()
+  })
+
+  test('shows the minimum points cost next to each detachment', async ({ page }) => {
+    const dialog = page.getByRole('dialog', { name: 'Add Detachment' })
+
+    await expect(
+      dialog.locator('.det-option').filter({ hasText: 'Mutable Detachment' }),
+    ).toContainText('340 pts')
+
+    await dialog.getByRole('button', { name: 'Support', exact: true }).click()
+    await expect(
+      dialog.locator('.det-option').filter({ hasText: 'Support Detachment' }),
+    ).toContainText('50 pts')
+  })
+})
+
 test.describe('List Home Management', () => {
   test.beforeEach(async ({ page }) => {
     await resetLists(page)

--- a/tests/unit/points.test.ts
+++ b/tests/unit/points.test.ts
@@ -1,0 +1,74 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import type { ArmyDef } from '../../src/entities/army'
+import { detachmentMinCost } from '../../src/entities/points'
+
+function createArmyDef(): ArmyDef {
+  return {
+    name: 'Test Army',
+    slug: 'test-army',
+    strategyRating: 3,
+    specialRules: [],
+    restrictions: [],
+    unitSpecialRules: [],
+    detachments: [
+      {
+        name: 'Mutable Detachment',
+        group: 'Core',
+        units: [
+          { unitName: 'Test Tank', min: 1, max: 3 },
+          { unitName: 'Test Predator', count: 3, min: 3, max: 6 },
+        ],
+        availableUpgrades: [],
+        restrictions: [],
+      },
+    ],
+    upgrades: [],
+    units: [
+      {
+        name: 'Test Tank',
+        cost: 100,
+        type: 'AV',
+        speed: '25cm',
+        armour: '4+',
+        cc: '6+',
+        ff: '4+',
+        weaponSlots: [
+          {
+            kind: 'choice',
+            choices: [
+              {
+                weaponName: 'Plasma Cannon',
+                range: '30cm',
+                firepower: 'AT4+ AP4+',
+                additionalCost: 10,
+              },
+              { weaponName: 'Lascannon', range: '45cm', firepower: 'AT4+', additionalCost: 5 },
+            ],
+          },
+        ],
+      },
+      {
+        name: 'Test Predator',
+        cost: 80,
+        type: 'AV',
+        speed: '20cm',
+        armour: '4+',
+        cc: '6+',
+        ff: '5+',
+        weaponSlots: [
+          { kind: 'fixed', weaponName: 'Predator Cannon', range: '45cm', firepower: 'AT5+ AP5+' },
+        ],
+      },
+    ],
+  }
+}
+
+test('detachmentMinCost includes the cheapest option for each choice weapon slot', () => {
+  const armyDef = createArmyDef()
+  const detachmentDef = armyDef.detachments[0]
+
+  // Test Tank: min 1 * (100 + cheapest choice 5) = 105
+  // Test Predator: count 3 * 80 (no choice slots) = 240
+  assert.equal(detachmentMinCost(detachmentDef, armyDef), 105 + 240)
+})


### PR DESCRIPTION
Adds detachmentMinCost to entities/points.ts, computing the cost of a
detachment's mandatory base units at their minimum count, and displays
it next to each option in AddDetachmentDialog.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0135dYB6HYA3XA5jtfChmPvG