### PR TITLE
Add min % group spend restriction alongside existing max restriction

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -126,7 +126,8 @@ Weapon selections are **per individual unit instance** — each model in a forma
   "strategyRating": 5,
   "specialRules": [{ "title": "", "text": "" }],
   "restrictions": [
-    { "type": "max_group_percentage", "group": "Support", "maxPercentage": 30 }
+    { "type": "max_group_percentage", "group": "Support", "maxPercentage": 30 },
+    { "type": "min_group_percentage", "group": "Core", "minPercentage": 25 }
   ],
   "detachments": [...],
   "upgrades": [...],

--- a/src/data/armies/playwright-test-army.json
+++ b/src/data/armies/playwright-test-army.json
@@ -3,7 +3,10 @@
   "slug": "playwright-test-army",
   "strategyRating": 3,
   "specialRules": [],
-  "restrictions": [],
+  "restrictions": [
+    { "type": "min_group_percentage", "group": "Core", "minPercentage": 10 },
+    { "type": "max_group_percentage", "group": "Support", "maxPercentage": 1 }
+  ],
   "detachments": [
     {
       "name": "Mutable Detachment",

--- a/src/entities/army.ts
+++ b/src/entities/army.ts
@@ -178,11 +178,17 @@ export interface DetachmentDef {
 
 // ─── Army definition ─────────────────────────────────────────────────────────
 
-export type ArmyRestriction = {
-  type: 'max_group_percentage'
-  group: string
-  maxPercentage: number
-}
+export type ArmyRestriction =
+  | {
+      type: 'max_group_percentage'
+      group: string
+      maxPercentage: number
+    }
+  | {
+      type: 'min_group_percentage'
+      group: string
+      minPercentage: number
+    }
 
 export interface SpecialRule {
   title: string

--- a/src/entities/validation.ts
+++ b/src/entities/validation.ts
@@ -16,12 +16,23 @@ export function validateArmyRestrictions(list: ArmyList, armyDef: ArmyDef): Vali
 
   for (const restriction of armyDef.restrictions) {
     const groupPoints = calculateGroupPoints(list.entries, restriction.group, armyDef)
-    const threshold = list.pointsLimit * (restriction.maxPercentage / 100)
-    if (groupPoints > threshold) {
-      results.push({
-        type: 'warning',
-        message: `${restriction.group} detachments cost ${groupPoints}pts — max ${restriction.maxPercentage}% of ${list.pointsLimit}pts (${threshold}pts).`,
-      })
+
+    if (restriction.type === 'max_group_percentage') {
+      const threshold = list.pointsLimit * (restriction.maxPercentage / 100)
+      if (groupPoints > threshold) {
+        results.push({
+          type: 'warning',
+          message: `${restriction.group} detachments cost ${groupPoints}pts — max ${restriction.maxPercentage}% of ${list.pointsLimit}pts (${threshold}pts).`,
+        })
+      }
+    } else {
+      const threshold = list.pointsLimit * (restriction.minPercentage / 100)
+      if (groupPoints < threshold) {
+        results.push({
+          type: 'warning',
+          message: `${restriction.group} detachments cost ${groupPoints}pts — min ${restriction.minPercentage}% of ${list.pointsLimit}pts (${threshold}pts).`,
+        })
+      }
     }
   }
 

--- a/src/infrastructure/armySchema.ts
+++ b/src/infrastructure/armySchema.ts
@@ -137,11 +137,18 @@ export const DetachmentDefSchema = z.object({
 
 // ─── Army definition ─────────────────────────────────────────────────────────
 
-export const ArmyRestrictionSchema = z.object({
-  type: z.literal('max_group_percentage'),
-  group: z.string(),
-  maxPercentage: z.number(),
-})
+export const ArmyRestrictionSchema = z.discriminatedUnion('type', [
+  z.object({
+    type: z.literal('max_group_percentage'),
+    group: z.string(),
+    maxPercentage: z.number(),
+  }),
+  z.object({
+    type: z.literal('min_group_percentage'),
+    group: z.string(),
+    minPercentage: z.number(),
+  }),
+])
 
 export const SpecialRuleSchema = z.object({
   title: z.string(),

--- a/src/views/ArmyView.vue
+++ b/src/views/ArmyView.vue
@@ -40,6 +40,9 @@ const unitGroups = computed(() => (army.value ? groupUnitsForReference(army.valu
           <template v-if="r.type === 'max_group_percentage'">
             Max {{ r.maxPercentage }}% of points on <strong>{{ r.group }}</strong> detachments
           </template>
+          <template v-else-if="r.type === 'min_group_percentage'">
+            Min {{ r.minPercentage }}% of points on <strong>{{ r.group }}</strong> detachments
+          </template>
         </li>
       </ul>
     </section>

--- a/src/views/ListReferenceView.vue
+++ b/src/views/ListReferenceView.vue
@@ -38,6 +38,9 @@ const unitGroups = computed(() =>
           <template v-if="r.type === 'max_group_percentage'">
             Max {{ r.maxPercentage }}% of points on <strong>{{ r.group }}</strong> detachments
           </template>
+          <template v-else-if="r.type === 'min_group_percentage'">
+            Min {{ r.minPercentage }}% of points on <strong>{{ r.group }}</strong> detachments
+          </template>
         </li>
       </ul>
     </section>

--- a/src/views/PrintView.vue
+++ b/src/views/PrintView.vue
@@ -115,7 +115,12 @@ const relevantSpecialRules = computed<SpecialRuleDef[]>(() => {
     <!-- Restrictions summary -->
     <div v-if="armyDef.restrictions.length > 0" class="restrictions-summary">
       <p v-for="r in armyDef.restrictions" :key="r.type + r.group" class="restriction-line">
-        Max {{ r.maxPercentage }}% of points on {{ r.group }} detachments
+        <template v-if="r.type === 'max_group_percentage'">
+          Max {{ r.maxPercentage }}% of points on {{ r.group }} detachments
+        </template>
+        <template v-else-if="r.type === 'min_group_percentage'">
+          Min {{ r.minPercentage }}% of points on {{ r.group }} detachments
+        </template>
       </p>
     </div>
 

--- a/tests/playwright/army-restrictions.spec.ts
+++ b/tests/playwright/army-restrictions.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from '@playwright/test'
+import { addDetachment, createPlaywrightTestList } from './helpers'
+
+// Playwright Test Army restrictions (src/data/armies/playwright-test-army.json):
+//   min 10% of points on Core detachments, max 1% of points on Support detachments
+// At the default 3000pt list, that's a 300pts floor for Core and a 30pts ceiling for Support.
+
+test.describe('Army Restrictions', () => {
+  test.beforeEach(async ({ page }) => {
+    await createPlaywrightTestList(page, 'Restrictions Test')
+  })
+
+  test('warns on min/max group percentage violations and clears once satisfied', async ({
+    page,
+  }) => {
+    const warning = page.locator('.validation-message')
+
+    await test.step('Empty list violates the Core minimum', async () => {
+      await expect(warning).toContainText(
+        'Core detachments cost 0pts — min 10% of 3000pts (300pts)',
+      )
+    })
+
+    await test.step('Adding the Mutable Detachment satisfies the Core minimum', async () => {
+      await addDetachment(page, 'Mutable Detachment', 'Core')
+      await expect(warning).toContainText('List is valid')
+    })
+
+    await test.step('Adding the Support Detachment exceeds the Support maximum', async () => {
+      await addDetachment(page, 'Support Detachment', 'Support')
+      await expect(warning).toContainText(
+        'Support detachments cost 50pts — max 1% of 3000pts (30pts)',
+      )
+    })
+  })
+})

--- a/tests/unit/validation.test.ts
+++ b/tests/unit/validation.test.ts
@@ -1,0 +1,140 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import type { ArmyDef } from '../../src/entities/army'
+import type { ArmyList } from '../../src/entities/list'
+import { validateArmyRestrictions } from '../../src/entities/validation'
+
+function createArmyDef(): ArmyDef {
+  return {
+    name: 'Test Army',
+    slug: 'test-army',
+    strategyRating: 3,
+    specialRules: [],
+    restrictions: [
+      { type: 'max_group_percentage', group: 'Support', maxPercentage: 30 },
+      { type: 'min_group_percentage', group: 'Core', minPercentage: 50 },
+    ],
+    unitSpecialRules: [],
+    detachments: [
+      {
+        name: 'Core Detachment',
+        group: 'Core',
+        units: [{ unitName: 'Test Tank', count: 1 }],
+        availableUpgrades: [],
+        restrictions: [],
+      },
+      {
+        name: 'Support Detachment',
+        group: 'Support',
+        units: [{ unitName: 'Support Platform', count: 1 }],
+        availableUpgrades: [],
+        restrictions: [],
+      },
+    ],
+    upgrades: [],
+    units: [
+      {
+        name: 'Test Tank',
+        cost: 100,
+        type: 'AV',
+        speed: '25cm',
+        armour: '4+',
+        cc: '6+',
+        ff: '4+',
+        weaponSlots: [],
+      },
+      {
+        name: 'Support Platform',
+        cost: 100,
+        type: 'LV',
+        speed: '15cm',
+        armour: '5+',
+        cc: '6+',
+        ff: '5+',
+        weaponSlots: [],
+      },
+    ],
+  }
+}
+
+function createList(entries: ArmyList['entries']): ArmyList {
+  return {
+    id: 'list-1',
+    name: 'Test List',
+    pointsLimit: 1000,
+    armySlug: 'test-army',
+    entries,
+  }
+}
+
+test('validateArmyRestrictions warns when a group exceeds its max percentage', () => {
+  const armyDef = createArmyDef()
+  const list = createList([
+    {
+      id: 'core-1',
+      detachmentName: 'Core Detachment',
+      baseUnits: [{ unitName: 'Test Tank', instances: [{ weaponSelections: [] }] }],
+      appliedUpgrades: [],
+    },
+    {
+      id: 'support-1',
+      detachmentName: 'Support Detachment',
+      baseUnits: [{ unitName: 'Support Platform', instances: [{ weaponSelections: [] }] }],
+      appliedUpgrades: [],
+    },
+  ])
+
+  // Support: 100pts, max 30% of 1000pts = 300pts -> not exceeded
+  // Core: 100pts, min 50% of 1000pts = 500pts -> exceeded (below minimum)
+  const results = validateArmyRestrictions(list, armyDef)
+
+  assert.equal(results.length, 1)
+  assert.match(results[0].message, /Core detachments cost 100pts — min 50% of 1000pts \(500pts\)/)
+})
+
+test('validateArmyRestrictions warns when a group exceeds its max percentage and is below its min', () => {
+  const armyDef = createArmyDef()
+  const list = createList([
+    {
+      id: 'support-1',
+      detachmentName: 'Support Detachment',
+      baseUnits: [
+        { unitName: 'Support Platform', instances: [{ weaponSelections: [] }, { weaponSelections: [] }, { weaponSelections: [] }, { weaponSelections: [] }] },
+      ],
+      appliedUpgrades: [],
+    },
+  ])
+
+  // Support: 400pts, max 30% of 1000pts = 300pts -> exceeded
+  // Core: 0pts, min 50% of 1000pts = 500pts -> exceeded (below minimum)
+  const results = validateArmyRestrictions(list, armyDef)
+
+  assert.equal(results.length, 2)
+  assert.ok(results.some((r) => /Support detachments cost 400pts — max 30%/.test(r.message)))
+  assert.ok(results.some((r) => /Core detachments cost 0pts — min 50%/.test(r.message)))
+})
+
+test('validateArmyRestrictions has no warnings when both min and max are satisfied', () => {
+  const armyDef = createArmyDef()
+  const list = createList([
+    {
+      id: 'core-1',
+      detachmentName: 'Core Detachment',
+      baseUnits: [
+        { unitName: 'Test Tank', instances: [{ weaponSelections: [] }, { weaponSelections: [] }, { weaponSelections: [] }, { weaponSelections: [] }, { weaponSelections: [] }, { weaponSelections: [] }] },
+      ],
+      appliedUpgrades: [],
+    },
+    {
+      id: 'support-1',
+      detachmentName: 'Support Detachment',
+      baseUnits: [{ unitName: 'Support Platform', instances: [{ weaponSelections: [] }] }],
+      appliedUpgrades: [],
+    },
+  ])
+
+  // Core: 600pts >= 500pts min. Support: 100pts <= 300pts max.
+  const results = validateArmyRestrictions(list, armyDef)
+
+  assert.deepEqual(results, [])
+})


### PR DESCRIPTION
Army definitions can now declare both max_group_percentage and
min_group_percentage restrictions per detachment group, checked
against the list's points limit and surfaced as warnings, matching
the existing max-restriction UX.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XNzoJRgyAgAYyk5AsBehWb