### PR TITLE
Add GitHub Action to update epic-armageddon-lists-data

### DIFF
--- a/.github/workflows/update-lists-data.yml
+++ b/.github/workflows/update-lists-data.yml
@@ -1,0 +1,51 @@
+name: Update epic-armageddon-lists-data
+
+on:
+  workflow_dispatch:
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Check for newer version
+        id: versions
+        run: |
+          PINNED=$(node -p "require('./package-lock.json').packages['node_modules/epic-armageddon-lists-data'].version")
+          LATEST=$(npm view epic-armageddon-lists-data version)
+          echo "pinned=$PINNED" >> $GITHUB_OUTPUT
+          echo "latest=$LATEST" >> $GITHUB_OUTPUT
+          if [ "$PINNED" != "$LATEST" ]; then
+            echo "update_needed=true" >> $GITHUB_OUTPUT
+          else
+            echo "update_needed=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Update dependency
+        if: steps.versions.outputs.update_needed == 'true'
+        run: npm install epic-armageddon-lists-data@latest
+
+      - name: Create pull request
+        if: steps.versions.outputs.update_needed == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: update/epic-armageddon-lists-data-${{ steps.versions.outputs.latest }}
+          commit-message: "chore(deps): update epic-armageddon-lists-data to v${{ steps.versions.outputs.latest }}"
+          title: "chore(deps): update epic-armageddon-lists-data to v${{ steps.versions.outputs.latest }}"
+          body: |
+            Updates `epic-armageddon-lists-data` from `v${{ steps.versions.outputs.pinned }}` → `v${{ steps.versions.outputs.latest }}`.
+
+            **Checklist**
+            - [ ] Verify army data changes look correct
+            - [ ] Run `npm run validate` to confirm schema compatibility
+          labels: dependencies


### PR DESCRIPTION
## Summary

- Adds a manually-triggered (`workflow_dispatch`) GitHub Action that checks npm for a newer version of `epic-armageddon-lists-data`
- If a newer version is found, it runs `npm install epic-armageddon-lists-data@latest` and opens a PR with the bumped `package.json` and `package-lock.json`
- PRs are created on a version-specific branch (`update/epic-armageddon-lists-data-<version>`), so re-running the action won't duplicate PRs for the same version

## Test plan

- [ ] Trigger the workflow manually via the Actions tab
- [ ] If a newer version exists on npm, verify a PR is opened with the correct version bump
- [ ] If already up to date, verify the workflow exits without creating a PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)