### PR TITLE
Improve mobile layout for unit editors and special rules

### DIFF
--- a/src/components/army/SpecialRulesTable.vue
+++ b/src/components/army/SpecialRulesTable.vue
@@ -7,37 +7,50 @@ defineProps<{
 </script>
 
 <template>
-  <div class="army-reference-table">
-    <table class="army-reference-table__native-table">
-      <thead>
-        <tr>
-          <th style="min-width: 160px">Rule</th>
-          <th>Description</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr v-for="rule in rules" :key="rule.title">
-          <td>{{ rule.title }}</td>
-          <td class="rule-description">
-            <p v-for="(paragraph, index) in rule.paragraphs" :key="index">{{ paragraph }}</p>
-            <template v-if="rule.paragraphs.length === 0">—</template>
-          </td>
-        </tr>
-      </tbody>
-    </table>
+  <div class="special-rules-list">
+    <article v-for="rule in rules" :key="rule.title" class="special-rule">
+      <h3 class="special-rule__title">{{ rule.title }}</h3>
+      <p v-for="(paragraph, index) in rule.paragraphs" :key="index" class="special-rule__text">
+        {{ paragraph }}
+      </p>
+      <p v-if="rule.paragraphs.length === 0" class="special-rule__text special-rule__text--empty">
+        —
+      </p>
+    </article>
   </div>
 </template>
 
 <style scoped>
-.army-reference-table .army-reference-table__native-table td.rule-description {
-  white-space: normal;
+.special-rules-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
 }
 
-.rule-description p:not(:last-child) {
-  margin-bottom: 0.5rem;
+.special-rule {
+  border: 1px solid var(--ea-surface-border);
+  border-radius: var(--ea-border-radius);
+  padding: 0.75rem 1rem;
+  background: var(--ea-surface-card);
 }
 
-.rule-description p {
-  margin-top: 0;
+.special-rule__title {
+  margin: 0 0 0.4rem;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.special-rule__text {
+  margin: 0;
+  color: var(--ea-text-muted-color);
+  line-height: 1.5;
+}
+
+.special-rule__text + .special-rule__text {
+  margin-top: 0.5rem;
+}
+
+.special-rule__text--empty {
+  color: var(--ea-text-faint-color);
 }
 </style>

--- a/src/components/editor/BaseUnitsPanel.vue
+++ b/src/components/editor/BaseUnitsPanel.vue
@@ -169,9 +169,6 @@ function setSameConfig(unitName: string, value: boolean, instances: UnitInstance
 }
 
 .instance-item {
-  flex-basis: 32%;
-  flex-shrink: 1;
-
   display: flex;
   flex-direction: column;
   gap: 0.2rem;

--- a/src/components/editor/DetachmentCard.vue
+++ b/src/components/editor/DetachmentCard.vue
@@ -226,6 +226,7 @@ function isTransportUpgrade(upgradeName: string): boolean {
   display: flex;
   gap: 0.5rem;
   flex-direction: row;
+  flex-wrap: wrap;
 }
 
 .instances {

--- a/src/components/editor/UnitInstanceEditor.vue
+++ b/src/components/editor/UnitInstanceEditor.vue
@@ -48,29 +48,71 @@ function currentChoice(choiceSlotIdx: number): string {
 </script>
 
 <template>
-  <div class="unit-instance-editor surface p-large stack-large">
-    <div class="header">{{ name }}</div>
-    <label v-for="(slot, slotIdx) in choiceSlots" :key="slotIdx" class="stack-small">
-      <span>{{ slot.name ?? `Weapon ${slotIdx + 1}` }}</span>
-      <select
-        :value="currentChoice(slotIdx)"
-        @change="
-          (event) =>
-            emit('weapon-change', slot.realIndex, (event.target as HTMLSelectElement).value)
-        "
-      >
-        <option v-for="choice in slot.choices" :key="choice.weaponName" :value="choice.weaponName">
-          {{ choice.label }}
-        </option>
-      </select>
-    </label>
+  <div class="unit-instance-editor surface">
+    <span v-if="name" class="instance-name">{{ name }}</span>
+    <div class="weapon-choices">
+      <label v-for="(slot, slotIdx) in choiceSlots" :key="slotIdx" class="weapon-choice">
+        <span class="slot-name">{{ slot.name ?? `Weapon ${slotIdx + 1}` }}</span>
+        <select
+          :value="currentChoice(slotIdx)"
+          @change="
+            (event) =>
+              emit('weapon-change', slot.realIndex, (event.target as HTMLSelectElement).value)
+          "
+        >
+          <option
+            v-for="choice in slot.choices"
+            :key="choice.weaponName"
+            :value="choice.weaponName"
+          >
+            {{ choice.label }}
+          </option>
+        </select>
+      </label>
+    </div>
   </div>
 </template>
 
 <style scoped>
+.unit-instance-editor {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem 0.75rem;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--ea-surface-border);
+  border-radius: var(--ea-radius-md);
+}
+
+.instance-name {
+  flex: 1 1 8rem;
+  min-width: 0;
+  font-weight: 500;
+}
+
+.weapon-choices {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 0.75rem;
+  flex: 2 1 12rem;
+}
+
 .weapon-choice {
   display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
+  align-items: center;
+  gap: 0.4rem;
+  flex: 1 1 12rem;
+  min-width: 0;
+}
+
+.slot-name {
+  font-size: 0.8rem;
+  color: var(--ea-text-muted-color);
+  white-space: nowrap;
+}
+
+.weapon-choice select {
+  flex: 1 1 auto;
+  min-width: 0;
 }
 </style>

--- a/src/components/editor/UnitPanel.vue
+++ b/src/components/editor/UnitPanel.vue
@@ -158,8 +158,8 @@ function incrementAmount() {
 }
 
 .options {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
 }
 </style>

--- a/src/components/print/PrintDetachment.vue
+++ b/src/components/print/PrintDetachment.vue
@@ -161,6 +161,7 @@ const displayGroups = computed<DisplayUnitGroup[]>(() => {
       </span>
       <span class="det-points">{{ entryPoints }}pts</span>
     </header>
+    <div class="units-table-scroll">
     <table class="units-table">
       <thead>
         <tr>
@@ -207,6 +208,7 @@ const displayGroups = computed<DisplayUnitGroup[]>(() => {
         </template>
       </tbody>
     </table>
+    </div>
   </section>
 </template>
 
@@ -251,11 +253,22 @@ const displayGroups = computed<DisplayUnitGroup[]>(() => {
   font-weight: 600;
 }
 
+.units-table-scroll {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  margin-bottom: 0.5rem;
+}
+
 .units-table {
   width: 100%;
   border-collapse: collapse;
   font-size: 0.8rem;
-  margin-bottom: 0.5rem;
+}
+
+@media print {
+  .units-table-scroll {
+    overflow-x: visible;
+  }
 }
 
 .units-table th,

--- a/src/data/armies/playwright-test-army.json
+++ b/src/data/armies/playwright-test-army.json
@@ -120,6 +120,7 @@
       "armour": "4+",
       "cc": "6+",
       "ff": "5+",
+      "specialRuleNames": ["Walker"],
       "weaponSlots": [
         {
           "kind": "fixed",

--- a/tests/playwright/mobile-view.spec.ts
+++ b/tests/playwright/mobile-view.spec.ts
@@ -1,0 +1,74 @@
+import { test, expect } from '@playwright/test'
+import { addDetachment, createPlaywrightTestList, detachmentCard } from './helpers'
+
+test.describe('Mobile View Improvements', () => {
+  test.describe('Special rules as articles', () => {
+    test.beforeEach(async ({ page }) => {
+      await createPlaywrightTestList(page, 'Mobile Special Rules')
+      await page.getByRole('link', { name: 'Reference' }).click()
+      await expect(page).toHaveURL(/\/reference$/)
+    })
+
+    test('renders unit special rules as articles with headings and paragraphs', async ({
+      page,
+    }) => {
+      const section = page.locator('.army-section').filter({ hasText: 'Unit Special Rules' })
+      await expect(section.getByRole('heading', { name: 'Unit Special Rules' })).toBeVisible()
+
+      const walkerArticle = section.locator('article.special-rule').filter({ hasText: 'Walker' })
+      await expect(walkerArticle).toHaveCount(1)
+      await expect(walkerArticle.getByRole('heading', { name: 'Walker' })).toBeVisible()
+      await expect(walkerArticle.locator('p')).toContainText('dangerous terrain')
+    })
+
+    test('does not render the unit special rules as a table', async ({ page }) => {
+      const section = page.locator('.army-section').filter({ hasText: 'Unit Special Rules' })
+      await expect(section.locator('table')).toHaveCount(0)
+    })
+  })
+
+  test.describe('Unit instance editor rows', () => {
+    test.beforeEach(async ({ page }) => {
+      await createPlaywrightTestList(page, 'Mobile Instance Editor')
+      await addDetachment(page, 'Mutable Detachment')
+    })
+
+    test('renders one row per instance when weapons are configured individually', async ({
+      page,
+    }) => {
+      const card = detachmentCard(page, 'Mutable Detachment')
+
+      await test.step('Increase Test Tank count to 2', async () => {
+        await card.getByRole('button', { name: 'Increase Test Tank count' }).click()
+        await expect(card.getByLabel('Increase Test Tank count')).toBeVisible()
+      })
+
+      await test.step('Disable shared weapon options to edit each instance', async () => {
+        await card.getByText('use same weapon options').click()
+      })
+
+      const editors = card.locator('.unit-instance-editor')
+      await expect(editors).toHaveCount(2)
+
+      await test.step('Each row exposes the turret weapon choice', async () => {
+        for (let i = 0; i < 2; i++) {
+          const row = editors.nth(i)
+          await expect(row.locator('.slot-name')).toContainText('Turret')
+          await expect(row.locator('select')).toBeVisible()
+        }
+      })
+    })
+
+    test('per-instance weapon selection is independent across rows', async ({ page }) => {
+      const card = detachmentCard(page, 'Mutable Detachment')
+      await card.getByRole('button', { name: 'Increase Test Tank count' }).click()
+      await card.getByText('use same weapon options').click()
+
+      const editors = card.locator('.unit-instance-editor')
+      await editors.nth(0).locator('select').selectOption({ label: 'Plasma Cannon (+10pts)' })
+
+      await expect(editors.nth(0).locator('select')).toHaveValue('Plasma Cannon')
+      await expect(editors.nth(1).locator('select')).toHaveValue('Battle Cannon')
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Refactors the unit instance editor and special rules display to use flexible, responsive layouts that work better on mobile devices. The unit instance editor now displays as a horizontal flex row with the unit name and weapon choices inline, and special rules are rendered as individual article cards instead of a table.

## Key Changes

- **UnitInstanceEditor**: Converted from vertical stacked layout to horizontal flex layout with the instance name and weapon choices displayed inline. Weapon slots now use flexbox with proper wrapping and responsive sizing.
  - Added `.instance-name`, `.weapon-choices`, and `.slot-name` classes with appropriate styling
  - Removed `p-large` and `stack-large` utility classes in favor of explicit flex layout
  - Weapon choice labels are now smaller and muted for better visual hierarchy

- **SpecialRulesTable**: Replaced table-based layout with semantic article cards
  - Each rule now renders as an `<article class="special-rule">` with an `<h3>` heading and `<p>` paragraphs
  - Removed table markup entirely in favor of a flex column layout with consistent spacing
  - Improved visual hierarchy with proper typography and border styling

- **PrintDetachment**: Wrapped the units table in a `.units-table-scroll` container to enable horizontal scrolling on mobile while maintaining print compatibility
  - Added `overflow-x: auto` with `-webkit-overflow-scrolling: touch` for smooth mobile scrolling
  - Print media query ensures scrolling is disabled when printing

- **UnitPanel**: Changed `.options` grid layout to flex column for better mobile readability
  - Removed two-column grid in favor of single-column flex layout
  - Reduced gap from `0.75rem` to `0.5rem`

- **BaseUnitsPanel**: Removed `flex-basis: 32%` constraint from `.instance-item` to allow more flexible wrapping

- **DetachmentCard**: Added `flex-wrap: wrap` to `.instances` container for better mobile responsiveness

- **Test data**: Added `"specialRuleNames": ["Walker"]` to Test Tank unit definition to support new test coverage

## Testing

Added comprehensive Playwright tests in `mobile-view.spec.ts`:
- Validates special rules render as articles with proper semantic structure
- Confirms unit instance editor rows display correctly with independent weapon selection per instance
- Ensures per-instance weapon changes don't affect other instances

https://claude.ai/code/session_01SArA7t2ZTmav3jNa71pSv6